### PR TITLE
Expand README with project overview, build instructions, and feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some features include:
 - Nicknames
 - Name colors
 - Warps
-- Quick access menu
+- HotMenu (quick access menu)
 - Changelog
 - Schedule server restarts after plugin updates
 - Others
@@ -43,7 +43,11 @@ Feature code is mostly grouped by package:
 - `Music/` - atmospheric/music systems
 - `Commands/` - command handlers and command utilities
 - `notifications/` - tips and transaction/player notifications
-- `spaceship/`, `arena/`, `NotOverwatch/`, `Rewards/`, `hotmenu/` - gameplay systems and experiments
+- `spaceship/` - minecart ship flight test. key steer.
+- `arena/` - PvP kill gives XP orb.
+- `NotOverwatch/` - hero-style ability tests. gear name checks.
+- `Rewards/` - level-up rewards. enchant table blocked.
+- `hotmenu/` - press F. scroll pick. run command.
 - `Events/` and `packetwrappers/` - custom event plumbing and packet wrappers
 
 There is also a `trash/` folder containing older or unused classes kept for reference.
@@ -103,4 +107,6 @@ Registered commands (see `plugin.yml`) include:
 - The codebase has evolved over many years, so package names and features reflect both active systems and historical experiments.
 
 ## Disabled features
-- View-distance changing via `/view` is currently disabled (the command currently sends guidance text only).
+- `/view` command exists.
+- view-distance change disabled.
+- command sends guidance only.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MountainDewritoes
 Custom server plugin for the MLG Fortress Minecraft server.
 
-IP: mlg.robomwm.com
+IP: `mlg.robomwm.com`
 
 Some features include:
 
@@ -18,5 +18,89 @@ Some features include:
 - Health canisters
 - Health pickups
 - ArmorAugmentation (armor does stuff)
+- Voice lines
+- Tip notifications
+- Transaction notifications
+- Nicknames
+- Name colors
+- Warps
+- Quick access menu
+- Changelog
+- Schedule server restarts after plugin updates
 - Others
 - Seriously I can't seem to stop myself from adding more in here
+
+## What is in this repo
+This is a long-running "all-in-one" server plugin. It mixes gameplay features, quality-of-life systems, commands, and integrations used by the MLG Fortress network.
+
+The plugin entry point is:
+- `me.robomwm.MountainDewritoes.MountainDewritoes`
+
+Feature code is mostly grouped by package:
+- `combat/` and `combat/twoshot/` - combat tuning and weapon systems
+- `Sounds/` - hit/low-health/replacement sound behavior
+- `armor/` - armor augmentation logic
+- `Music/` - atmospheric/music systems
+- `Commands/` - command handlers and command utilities
+- `notifications/` - tips and transaction/player notifications
+- `spaceship/`, `arena/`, `NotOverwatch/`, `Rewards/`, `hotmenu/` - gameplay systems and experiments
+- `Events/` and `packetwrappers/` - custom event plumbing and packet wrappers
+
+There is also a `trash/` folder containing older or unused classes kept for reference.
+
+## Requirements
+- Java 21
+- Paper API `26.1.2+` (as declared in `pom.xml`)
+- Maven 3.x
+
+## Build
+```bash
+mvn clean package
+```
+
+The built plugin jar is shaded and produced under `target/`.
+
+## Runtime integrations
+MountainDewritoes supports many optional plugins through soft dependencies and runtime checks. Notable integrations include:
+- CustomItemRegistry
+- GrandioseAPI
+- SimpleClans
+- BetterTPA
+- Vault
+- ProtocolLib
+- PrettySimpleShop
+- ServerListPlus
+
+Behavior for several features is enabled only when corresponding plugins are present.
+
+## Commands
+Registered commands (see `plugin.yml`) include:
+- `nick` (aliases: `color`, `name`, `nickname`, ...)
+- `warp`
+- `mdebug`
+- `restart`, `restartnow`, `update`
+- `clearchat`
+- `tip`
+- `voice`
+- `start`
+- `music`
+- `shrug`
+- `lejail`
+- `reset`
+- `md`
+- `watchwinreward`
+- `newlog`, `deletelog`
+- `info`
+- `settings`
+- `view`
+- `changelog`
+- `login`
+- `syncconfigs`
+- `mop`
+
+## Notes
+- This project is intentionally practical rather than flashy.
+- The codebase has evolved over many years, so package names and features reflect both active systems and historical experiments.
+
+## Disabled features
+- View-distance changing via `/view` is currently disabled (the command currently sends guidance text only).


### PR DESCRIPTION
### Motivation
- Provide a comprehensive project README that describes what the repository contains and how to build and run the plugin.
- Surface runtime integrations, requirements, and common commands to help developers and server operators get started quickly.
- Clarify the plugin entry point and package organization to make navigation of the long-running codebase easier.

### Description
- Rewrote and expanded `README.md` to include a project overview, a feature list, and a detailed "What is in this repo" section with the plugin entry point `me.robomwm.MountainDewritoes.MountainDewritoes` and package grouping.
- Added explicit requirements including `Java 21`, Paper API `26.1.2+`, and `Maven 3.x`, and documented the build command `mvn clean package` and output location `target/`.
- Documented runtime integrations and optional soft-dependency plugins, and added a comprehensive list of registered commands (as declared in `plugin.yml`).
- Minor formatting and content adjustments such as formatting the IP as ``mlg.robomwm.com``, notes about disabled features, and a short project philosophy/notes section.

### Testing
- This change is documentation-only and no automated tests were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e58cc35810832097b556bdf6831a9d)